### PR TITLE
Don't use junk paths arg when unzipping

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,11 +10,16 @@ jobs:
     - uses: actions/checkout@v3
 
     - name: Run Buildpack Compile
-      run: ./bin/compile . . .
+      run: |
+        ./bin/compile . . .
       env:
         STACK: heroku-22
 
     - name: Check Installation
       run: |
-        .chrome-for-testing/bin/chrome --version
-        .chrome-for-testing/bin/chromedriver --version
+        # Trick the profile script into using working dir as HOME
+        HOME="$(pwd)"
+        # Verify profile script puts Chrome & Chromedriver on the PATH
+        source .profile.d/chrome-for-testing.sh
+        chrome --version
+        chromedriver --version

--- a/bin/compile
+++ b/bin/compile
@@ -34,8 +34,7 @@ function indent() {
 topic "Installing Chrome for Testing"
 
 INSTALL_DIR="$BUILD_DIR/.chrome-for-testing"
-BIN_DIR="$INSTALL_DIR/bin"
-mkdir -p "$BIN_DIR"
+mkdir -p "$INSTALL_DIR"
 
 # Detect if the old config var is still used
 if [ -f "$ENV_DIR/CHROMEDRIVER_VERSION" ]; then
@@ -63,24 +62,24 @@ echo "Downloading Chrome" | indent
 ZIP_URL="https://storage.googleapis.com/chrome-for-testing-public/$VERSION/linux64/chrome-linux64.zip"
 ZIP_LOCATION="$INSTALL_DIR/chrome.zip"
 curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 -o "${ZIP_LOCATION}" "${ZIP_URL}" | indent
-unzip -q -o "$ZIP_LOCATION" -d "$BIN_DIR" | indent
+unzip -q -o "$ZIP_LOCATION" -d "$INSTALL_DIR" | indent
 rm -f "$ZIP_LOCATION"
 
 echo "Downloading Chromedriver" | indent
 ZIP_URL="https://storage.googleapis.com/chrome-for-testing-public/$VERSION/linux64/chromedriver-linux64.zip"
 ZIP_LOCATION="$INSTALL_DIR/chromedriver.zip"
 curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 -o "${ZIP_LOCATION}" "${ZIP_URL}" | indent
-unzip -q -o "$ZIP_LOCATION" -d "$BIN_DIR" | indent
+unzip -q -o "$ZIP_LOCATION" -d "$INSTALL_DIR" | indent
 rm -f "$ZIP_LOCATION"
 
 source "$BUILDPACK_DIR/bin/install-chrome-dependencies"
 
 echo "Adding executables to PATH" | indent
 mkdir -p "$BUILD_DIR/.profile.d"
-echo "export PATH=\$HOME/.chrome-for-testing/bin/chrome-linux64:\$HOME/.chrome-for-testing/bin/chromedriver-linux64:\$PATH" >> "$BUILD_DIR/.profile.d/chrome-for-testing.sh"
+echo "export PATH=\$HOME/.chrome-for-testing/chrome-linux64:\$HOME/.chrome-for-testing/chromedriver-linux64:\$PATH" >> "$BUILD_DIR/.profile.d/chrome-for-testing.sh"
 
 # Verify the executables are actually present
-export PATH="$BUILD_DIR/.chrome-for-testing/bin/chrome-linux64:$BUILD_DIR/.chrome-for-testing/bin/chromedriver-linux64:$PATH"
+export PATH="$BUILD_DIR/.chrome-for-testing/chrome-linux64:$BUILD_DIR/.chrome-for-testing/chromedriver-linux64:$PATH"
 which chrome | indent
 which chromedriver | indent
 

--- a/bin/compile
+++ b/bin/compile
@@ -63,14 +63,14 @@ echo "Downloading Chrome" | indent
 ZIP_URL="https://storage.googleapis.com/chrome-for-testing-public/$VERSION/linux64/chrome-linux64.zip"
 ZIP_LOCATION="$INSTALL_DIR/chrome.zip"
 curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 -o "${ZIP_LOCATION}" "${ZIP_URL}" | indent
-unzip -q -j -o "$ZIP_LOCATION" -d "$BIN_DIR" | indent
+unzip -q -o "$ZIP_LOCATION" -d "$BIN_DIR" | indent
 rm -f "$ZIP_LOCATION"
 
 echo "Downloading Chromedriver" | indent
 ZIP_URL="https://storage.googleapis.com/chrome-for-testing-public/$VERSION/linux64/chromedriver-linux64.zip"
 ZIP_LOCATION="$INSTALL_DIR/chromedriver.zip"
 curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 -o "${ZIP_LOCATION}" "${ZIP_URL}" | indent
-unzip -q -j -o "$ZIP_LOCATION" -d "$BIN_DIR" | indent
+unzip -q -o "$ZIP_LOCATION" -d "$BIN_DIR" | indent
 rm -f "$ZIP_LOCATION"
 
 source "$BUILDPACK_DIR/bin/install-chrome-dependencies"

--- a/bin/compile
+++ b/bin/compile
@@ -77,10 +77,10 @@ source "$BUILDPACK_DIR/bin/install-chrome-dependencies"
 
 echo "Adding executables to PATH" | indent
 mkdir -p "$BUILD_DIR/.profile.d"
-echo "export PATH=\$HOME/.chrome-for-testing/bin:\$PATH" >> "$BUILD_DIR/.profile.d/chrome-for-testing.sh"
+echo "export PATH=\$HOME/.chrome-for-testing/bin/chrome-linux64:\$HOME/.chrome-for-testing/bin/chromedriver-linux64:\$PATH" >> "$BUILD_DIR/.profile.d/chrome-for-testing.sh"
 
 # Verify the executables are actually present
-export PATH="$BUILD_DIR/.chrome-for-testing/bin:$PATH"
+export PATH="$BUILD_DIR/.chrome-for-testing/bin/chrome-linux64:$BUILD_DIR/.chrome-for-testing/bin/chromedriver-linux64:$PATH"
 which chrome | indent
 which chromedriver | indent
 


### PR DESCRIPTION
Fix #5

Includes an improved Installation check, which validates that the buildpack's profile script actually puts `chrome` & `chromedriver` on the dyno's `PATH`.