### PR TITLE
Fix support for Heroku-24

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+.github/
+bin/test.sh
+Dockerfile

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,23 +6,12 @@ jobs:
   test:
     strategy:
       matrix:
-        stack: [heroku-20, heroku-22, heroku-24]
+        stack: [heroku-20, heroku-22]
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
-
-    - name: Run Buildpack Compile
-      run: |
-        ./bin/compile . . .
-      env:
-        STACK: ${{ matrix.stack }}
-
     - name: Check Installation
       run: |
         # Trick the profile script into using working dir as HOME
-        HOME="$(pwd)"
-        # Verify profile script puts Chrome & Chromedriver on the PATH
-        source .profile.d/chrome-for-testing.sh
-        chrome --version
-        chromedriver --version
+        ./bin/test.sh ${{ matrix.stack }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,7 +6,7 @@ jobs:
   test:
     strategy:
       matrix:
-        stack: [heroku-20, heroku-22]
+        stack: [heroku-20, heroku-22, heroku-24]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,12 +6,10 @@ jobs:
   test:
     strategy:
       matrix:
-        stack: [heroku-20, heroku-22, heroku-24]
+        stack_version: [20, 22, 24]
     runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3
     - name: Check Installation
-      run: |
-        # Trick the profile script into using working dir as HOME
-        ./bin/test.sh ${{ matrix.stack }}
+      run: ./bin/test.sh ${{ matrix.stack_version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,19 @@
+
+ARG BASE_IMAGE
+FROM $BASE_IMAGE
+USER root
+
+ARG STACK
+
+# Emulate the platform where root access is not available
+RUN useradd -m -d /app non-root-user
+RUN mkdir -p /app /cache /env
+RUN chown non-root-user /app /cache /env
+
+COPY --chown=non-root-user . /buildpack
+WORKDIR /app
+
+# Sanitize the environment seen by the buildpack, to prevent reliance on
+# environment variables that won't be present when it's run by Heroku CI.
+RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/detect /app
+RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/compile /app /cache /env

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,35 @@
+ARG STACK_VERSION
+FROM --platform=linux/amd64 heroku/heroku:${STACK_VERSION}-build as build
 
-ARG BASE_IMAGE
-FROM $BASE_IMAGE
+# This ARG duplication is required since the lines before and after the 'FROM' are in different scopes.
+ARG STACK_VERSION
+ENV STACK="heroku-${STACK_VERSION}"
+
+# On Heroku-24 and later the default user is not root.
+# Once support for Heroku-22 and older is removed, the `useradd` steps below can be removed.
 USER root
 
-ARG STACK
-
 # Emulate the platform where root access is not available
-RUN useradd -m -d /app non-root-user
-RUN mkdir -p /app /cache /env
-RUN chown non-root-user /app /cache /env
-
+RUN useradd -m non-root-user
+USER non-root-user
+RUN mkdir -p /tmp/build /tmp/cache /tmp/env
 COPY --chown=non-root-user . /buildpack
-WORKDIR /app
 
 # Sanitize the environment seen by the buildpack, to prevent reliance on
 # environment variables that won't be present when it's run by Heroku CI.
-RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/detect /app
-RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/compile /app /cache /env
+RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/detect /tmp/build
+RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/compile /tmp/build /tmp/cache /tmp/env
+
+# We must then test against the run image since that has fewer system libraries installed.
+FROM --platform=linux/amd64 heroku/heroku:${STACK_VERSION}
+USER root
+# Emulate the platform where root access is not available
+RUN useradd -m non-root-user
+USER non-root-user
+COPY --from=build --chown=non-root-user /tmp/build /app
+# Emulate the platform which sources all .profile.d/ scripts on app boot.
+RUN echo 'for f in /app/.profile.d/*; do source "${f}"; done' > /app/.profile
+ENV HOME=/app
+WORKDIR /app
+# We have to use a login bash shell otherwise the .profile script won't be run.
+CMD ["bash", "-l"]

--- a/bin/install-chrome-dependencies
+++ b/bin/install-chrome-dependencies
@@ -50,14 +50,11 @@ case "${STACK}" in
     # the package list is found by using ci:debug then running ldd $GOOGLE_CHROME_BIN | grep not
     # also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
     PACKAGES="
-      libappindicator1
-      libasound2
       libatk1.0-0
       libatk-bridge2.0-0
       libcairo-gobject2
       libdrm2
       libgbm1
-      libgconf-2-4
       libgtk-3-0
       libnspr4
       libnss3

--- a/bin/install-chrome-dependencies
+++ b/bin/install-chrome-dependencies
@@ -15,11 +15,41 @@ topic "Installing Chrome dependencies"
 
 # Install correct dependencies according to $STACK
 case "${STACK}" in
-  "heroku-20" | "heroku-22" | "heroku-24")
+  "heroku-20" | "heroku-22" )
     # the package list is found by using ci:debug then running ldd $GOOGLE_CHROME_BIN | grep not
     # also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
     PACKAGES="
       gconf-service
+      libappindicator1
+      libasound2
+      libatk1.0-0
+      libatk-bridge2.0-0
+      libcairo-gobject2
+      libdrm2
+      libgbm1
+      libgconf-2-4
+      libgtk-3-0
+      libnspr4
+      libnss3
+      libx11-xcb1
+      libxcb-dri3-0
+      libxcomposite1
+      libxcursor1
+      libxdamage1
+      libxfixes3
+      libxi6
+      libxinerama1
+      libxrandr2
+      libxshmfence1
+      libxss1
+      libxtst6
+      fonts-liberation
+    "
+    ;;
+  "heroku-24")
+    # the package list is found by using ci:debug then running ldd $GOOGLE_CHROME_BIN | grep not
+    # also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
+    PACKAGES="
       libappindicator1
       libasound2
       libatk1.0-0

--- a/bin/install-chrome-dependencies
+++ b/bin/install-chrome-dependencies
@@ -14,10 +14,10 @@
 topic "Installing Chrome dependencies"
 
 # Install correct dependencies according to $STACK
+# The package list is validated by bin/test.sh - see its output to identify any missing libraries.
+# Also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
 case "${STACK}" in
-  "heroku-20" | "heroku-22" )
-    # the package list is found by using ci:debug then running ldd $GOOGLE_CHROME_BIN | grep not
-    # also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
+  "heroku-20" | "heroku-22")
     PACKAGES="
       gconf-service
       libappindicator1
@@ -47,30 +47,18 @@ case "${STACK}" in
     "
     ;;
   "heroku-24")
-    # the package list is found by using ci:debug then running ldd $GOOGLE_CHROME_BIN | grep not
-    # also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
     PACKAGES="
-      libatk1.0-0
+      fonts-liberation
+      libasound2t64
       libatk-bridge2.0-0
-      libcairo-gobject2
-      libdrm2
+      libatk1.0-0
+      libcups2
       libgbm1
-      libgtk-3-0
-      libnspr4
-      libnss3
-      libx11-xcb1
-      libxcb-dri3-0
       libxcomposite1
-      libxcursor1
       libxdamage1
       libxfixes3
-      libxi6
-      libxinerama1
+      libxkbcommon0
       libxrandr2
-      libxshmfence1
-      libxss1
-      libxtst6
-      fonts-liberation
     "
     ;;
   *)

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,0 +1,4 @@
+STACK=$1
+BASE_IMAGE="heroku/${STACK/-/:}-build"
+docker build --progress=plain --build-arg="STACK=$STACK" --build-arg="BASE_IMAGE=$BASE_IMAGE" -t heroku-buildpack-chrome-for-testing .
+docker run heroku-buildpack-chrome-for-testing

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -1,4 +1,23 @@
-STACK=$1
-BASE_IMAGE="heroku/${STACK/-/:}-build"
-docker build --progress=plain --build-arg="STACK=$STACK" --build-arg="BASE_IMAGE=$BASE_IMAGE" -t heroku-buildpack-chrome-for-testing .
-docker run heroku-buildpack-chrome-for-testing
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+STACK_VERSION="${1:?'Error: The stack version number must be specified as the first argument.'}"
+
+set -x
+
+docker build --progress=plain --build-arg="STACK_VERSION=${STACK_VERSION}" -t heroku-buildpack-chrome-for-testing .
+
+# Note: All of the container commands must be run via a login bash shell otherwise the profile.d scripts won't be run.
+
+# Check the profile.d scripts correctly added the binaries to PATH.
+docker run heroku-buildpack-chrome-for-testing bash -l -c 'chrome --version'
+docker run heroku-buildpack-chrome-for-testing bash -l -c 'chromedriver --version'
+
+# Check that there are no missing dynamically linked libraries.
+docker run heroku-buildpack-chrome-for-testing bash -l -c 'ldd $(which chrome)'
+docker run heroku-buildpack-chrome-for-testing bash -l -c 'ldd $(which chromedriver)'
+
+# Check Chrome can fully boot in both new and old headless modes.
+docker run heroku-buildpack-chrome-for-testing bash -l -c 'chrome --no-sandbox --headless=new --screenshot https://google.com'
+docker run heroku-buildpack-chrome-for-testing bash -l -c 'chrome --no-sandbox --headless=old --screenshot https://google.com'


### PR DESCRIPTION
This also changes the test to run inside of a dockerfile using our base builder images. Prior to this, we were getting passing tests on a broken heroku-24 build that was attempting to install packages that no longer exist in ubuntu 24.