### PR TITLE
Invalidate the cache when the stack changes

### DIFF
--- a/bin/install-chrome-dependencies
+++ b/bin/install-chrome-dependencies
@@ -51,19 +51,36 @@ case "${STACK}" in
     error "STACK must be 'heroku-20', 'heroku-22' or 'heroku-24', not '${STACK}'."
 esac
 
-if [ ! -f $CACHE_DIR/PURGED_CACHE_V1 ]; then
-  echo "Purging cache" | indent
-  rm -rf $CACHE_DIR/apt
-  rm -rf $CACHE_DIR/archives
-  rm -rf $CACHE_DIR/lists
-  touch $CACHE_DIR/PURGED_CACHE_V1
+# We must invalidate the cache if the stack changes, since the cached indexes and
+# package archives will not be compatible with a different Ubuntu version.
+# This file really should be inside "${CACHE_DIR}/apt" not "${CACHE_DIR}/.apt", however,
+# the generic APT buildpack has used the wrong directory name for its version file for some
+# time, so we have to match that, given this buildpack and the APT buildpack share all the
+# other cached APT directories.
+STACK_VERSION_FILE="${CACHE_DIR}/.apt/STACK"
+
+if [[ -d "${CACHE_DIR}/apt" ]]; then
+  if [[ -f "${STACK_VERSION_FILE}" ]]; then
+    CACHED_STACK=$(cat "${STACK_VERSION_FILE}")
+  else
+    CACHED_STACK=
+  fi
+
+  if [[ "${CACHED_STACK}" == "${STACK}" ]]; then
+    echo "Reusing APT cache" | indent
+  elif [[ -z "${CACHED_STACK}" ]]; then
+    # Older versions of the buildpack won't have written the version file.
+    # (Plus any other broken APT-related buildpacks that don't invalidate on cache change.)
+    echo "Clearing APT cache since it's missing the stack version metadata file." | indent
+    rm -rf "${CACHE_DIR}/apt"
+  else
+    echo "Clearing APT cache since stack changed from ${CACHED_STACK} to ${STACK}" | indent
+    rm -rf "${CACHE_DIR}/apt"
+  fi
 fi
 
-# This is where the original buildpack installed Chrome itself,
-# but Chrome for Testing is installed from direct downloads.
-#
-# echo "Installing Google Chrome from the $channel channel." | indent
-# PACKAGES="$PACKAGES https://dl.google.com/linux/direct/google-chrome-${channel}_current_amd64.deb"
+mkdir -p "${CACHE_DIR}/.apt"
+echo "${STACK}" > "${STACK_VERSION_FILE}"
 
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
 APT_STATE_DIR="$CACHE_DIR/apt/state"
@@ -73,7 +90,7 @@ mkdir -p "$APT_STATE_DIR/lists/partial"
 
 APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
 
-echo "Updating apt caches" | indent
+echo "Updating APT package index" | indent
 apt-get $APT_OPTIONS update | indent
 
 for PACKAGE in $PACKAGES; do


### PR DESCRIPTION
Previously the buildpack did not invalidate the cache when the stack changed, which causes the errors seen in #19. This will be particularly an issue when Heroku-24 is GAed and Heroku-20 deprecated, since there will be a number of apps changing stack for the first time after switching to this buildpack.

Now, the stack version is stored in the cache and if it differs from the current stack version (or the version file is missing since the cache is from an older version of this buildpack), the cache will be purged.

This implementation is an improved version of what's implemented for the generic APT buildpack (I'll be backporting those improvements over to that buildpack shortly):
https://github.com/heroku/heroku-buildpack-apt/blob/4eb4b35d35d0178e5cef73d6998a26ba2c9bbf17/bin/compile#L42-L86

Longer term we should probably re-evaluate whether we need the cache at all, since from my testing locally it offered very little benefit, and if anything causes a number of issues (particularly when several APT-using buildpacks are set on an app at the same time, given the shared Debian archives directory and install strategy).

Fixes #19.