### PR TITLE
Support using an Older Chrome Release

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,6 +5,8 @@ FROM --platform=linux/amd64 heroku/heroku:${STACK_VERSION}-build as build
 ARG STACK_VERSION
 ENV STACK="heroku-${STACK_VERSION}"
 
+ARG GOOGLE_CHROME_MILESTONE_OFFSET
+
 # On Heroku-24 and later the default user is not root.
 # Once support for Heroku-22 and older is removed, the `useradd` steps below can be removed.
 USER root
@@ -14,6 +16,9 @@ RUN useradd -m non-root-user
 USER non-root-user
 RUN mkdir -p /tmp/build /tmp/cache /tmp/env
 COPY --chown=non-root-user . /buildpack
+
+# Emulate the platform providing app config vars via env directory
+RUN if [ -n "${GOOGLE_CHROME_MILESTONE_OFFSET}" ]; then echo "${GOOGLE_CHROME_MILESTONE_OFFSET}" > /tmp/env/GOOGLE_CHROME_MILESTONE_OFFSET; fi
 
 # Sanitize the environment seen by the buildpack, to prevent reliance on
 # environment variables that won't be present when it's run by Heroku CI.

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ config variable to `Stable`, `Beta`, `Dev`, or `Canary`, and then deploy/build t
 ## Using an Older Chrome Release
 
 If the most recent stable Chrome or Chromedriver release has problems, perhaps due to an 
-app dependecy like Selenium not being compatible yet, an older major release can be installed.
+app dependency like Selenium not being compatible yet, an older major release can be installed.
 
 You can control how many major versions (milestones) back to install, with 
 `GOOGLE_CHROME_MILESTONE_OFFSET` config variable.

--- a/README.md
+++ b/README.md
@@ -25,6 +25,25 @@ by [Google](https://googlechromelabs.github.io/chrome-for-testing/).
 You can control the channel of the release by setting the `GOOGLE_CHROME_CHANNEL`
 config variable to `Stable`, `Beta`, `Dev`, or `Canary`, and then deploy/build the app.
 
+## Using an Older Chrome Release
+
+If the most recent stable Chrome or Chromedriver release has problems, perhaps due to an 
+app dependecy like Selenium not being compatible yet, an older major release can be installed.
+
+You can control how many major versions (milestones) back to install, with 
+`GOOGLE_CHROME_MILESTONE_OFFSET` config variable.
+
+*This version offset strategy does not lock the app to a specific Chrome version. It will still update automatically, but lag behind by the specified offset.*
+
+Set `GOOGLE_CHROME_MILESTONE_OFFSET` to a negative index, such as:
+* `-4` for the previous major stable release
+* `-3` for the current major stable release
+* `-2` for the beta release
+* `-1` for the dev release.
+
+During build, this offset indexes the milestone-sorted data returned from the Chrome for Testing API [`latest-versions-per-milestone.json`](https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone.json),
+in order to resolve a specific version to install.
+
 ## Migrating from Separate Buildpacks
 
 ### Remove Existing Installations

--- a/bin/compile
+++ b/bin/compile
@@ -65,8 +65,9 @@ if [ -f "$ENV_DIR/GOOGLE_CHROME_MILESTONE_OFFSET" ]; then
   fi
 
   latest_version_per_milestone="$(curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 "https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone.json")"
-  VERSION="$(echo $latest_version_per_milestone | jq --arg milestone_offset="$milestone_offset" value '.milestones | map(.) | sort_by(.milestone)[($milestone_offset | tonumber)] | .version')"
+  VERSION="$(echo $latest_version_per_milestone | jq --raw-output --arg milestone_offset "$milestone_offset" '.milestones | map(.) | sort_by(.milestone)[($milestone_offset | tonumber)] | .version')"
   echo "Resolved milestone offset $milestone_offset to version $VERSION" | indent
+  INSTALLED_DESCRIPTION="milestone offset $milestone_offset"
 
 else
   # Detect requested channel or default to stable
@@ -80,6 +81,7 @@ else
   CHANNEL="$(echo -n "$channel" | awk '{ print toupper($0) }')"
   VERSION="$(curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_$CHANNEL")"
   echo "Resolved $CHANNEL version $VERSION" | indent
+  INSTALLED_DESCRIPTION="$CHANNEL"
 fi
 
 echo "Downloading Chrome" | indent
@@ -107,4 +109,4 @@ export PATH="$BUILD_DIR/.chrome-for-testing/chrome-linux64:$BUILD_DIR/.chrome-fo
 which chrome | indent
 which chromedriver | indent
 
-echo "Installed Chrome for Testing $CHANNEL version $VERSION" | indent
+echo "Installed Chrome for Testing $INSTALLED_DESCRIPTION version $VERSION" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -59,7 +59,7 @@ if [ -f "$ENV_DIR/GOOGLE_CHROME_MILESTONE_OFFSET" ]; then
     JQ_DIR="$INSTALL_DIR/jq"
     mkdir -p "$JQ_DIR"
     cd "$JQ_DIR"
-    wget --quiet -O jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
+    wget --quiet -O jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$ARCH
     chmod +x jq
     cd -
   fi

--- a/bin/compile
+++ b/bin/compile
@@ -51,20 +51,6 @@ if [ -f "$ENV_DIR/GOOGLE_CHROME_MILESTONE_OFFSET" ]; then
   milestone_offset=$(cat "$ENV_DIR/GOOGLE_CHROME_MILESTONE_OFFSET")
   echo "Using env var GOOGLE_CHROME_MILESTONE_OFFSET=$milestone_offset" | indent
 
-  # jq is required to parse Chrome for Testing JSON API response
-  if which jq; then
-    echo "Using existing jq" | indent
-  else
-    echo "Installing jq" | indent
-    JQ_DIR="$INSTALL_DIR/jq"
-    mkdir -p "$JQ_DIR"
-    cd "$JQ_DIR"
-    wget --quiet -O jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$ARCH
-    chmod +x jq
-    PATH="$JQ_DIR:$PATH"
-    cd -
-  fi
-
   latest_version_per_milestone="$(curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 "https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone.json")"
   VERSION="$(echo $latest_version_per_milestone | jq --raw-output --arg milestone_offset "$milestone_offset" '.milestones | map(.) | sort_by(.milestone)[($milestone_offset | tonumber)] | .version')"
   echo "Resolved milestone offset $milestone_offset to version $VERSION" | indent

--- a/bin/compile
+++ b/bin/compile
@@ -46,17 +46,41 @@ if which chrome; then
   error "Chrome is already installed. This buildpack now installs a compatible version of Chrome. Please, remove the other Chrome installation. Chrome may have been installed by another buildpack (such as heroku/heroku-buildpack-google-chrome buildpack), which should no longer be used with this buildpack."
 fi
 
-# Detect requested channel or default to stable
-if [ -f "$ENV_DIR/GOOGLE_CHROME_CHANNEL" ]; then
-  channel=$(cat "$ENV_DIR/GOOGLE_CHROME_CHANNEL")
-  echo "Using env var GOOGLE_CHROME_CHANNEL=$channel" | indent
+# Detect milestone offset or channel-based version selection
+if [ -f "$ENV_DIR/GOOGLE_CHROME_MILESTONE_OFFSET" ]; then
+  milestone_offset=$(cat "$ENV_DIR/GOOGLE_CHROME_MILESTONE_OFFSET")
+  echo "Using env var GOOGLE_CHROME_MILESTONE_OFFSET=$milestone_offset" | indent
+
+  # jq is required to parse Chrome for Testing JSON API response
+  if which jq; then
+    echo "Using existing jq" | indent
+  else
+    echo "Installing jq" | indent
+    JQ_DIR="$INSTALL_DIR/jq"
+    mkdir -p "$JQ_DIR"
+    cd "$JQ_DIR"
+    wget --quiet -O jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-amd64
+    chmod +x jq
+    cd -
+  fi
+
+  latest_version_per_milestone="$(curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 "https://googlechromelabs.github.io/chrome-for-testing/latest-versions-per-milestone.json")"
+  VERSION="$(echo $latest_version_per_milestone | jq --arg milestone_offset="$milestone_offset" value '.milestones | map(.) | sort_by(.milestone)[($milestone_offset | tonumber)] | .version')"
+  echo "Resolved milestone offset $milestone_offset to version $VERSION" | indent
+
 else
-  channel=stable
+  # Detect requested channel or default to stable
+  if [ -f "$ENV_DIR/GOOGLE_CHROME_CHANNEL" ]; then
+    channel=$(cat "$ENV_DIR/GOOGLE_CHROME_CHANNEL")
+    echo "Using env var GOOGLE_CHROME_CHANNEL=$channel" | indent
+  else
+    channel=stable
+  fi
+  # The current version endpoint requires ALL CAPS.
+  CHANNEL="$(echo -n "$channel" | awk '{ print toupper($0) }')"
+  VERSION="$(curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_$CHANNEL")"
+  echo "Resolved $CHANNEL version $VERSION" | indent
 fi
-# The current version endpoint requires ALL CAPS.
-CHANNEL="$(echo -n "$channel" | awk '{ print toupper($0) }')"
-VERSION="$(curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_$CHANNEL")"
-echo "Resolved $CHANNEL version $VERSION" | indent
 
 echo "Downloading Chrome" | indent
 ZIP_URL="https://storage.googleapis.com/chrome-for-testing-public/$VERSION/linux64/chrome-linux64.zip"

--- a/bin/compile
+++ b/bin/compile
@@ -61,6 +61,7 @@ if [ -f "$ENV_DIR/GOOGLE_CHROME_MILESTONE_OFFSET" ]; then
     cd "$JQ_DIR"
     wget --quiet -O jq https://github.com/jqlang/jq/releases/download/jq-1.7.1/jq-linux-$ARCH
     chmod +x jq
+    PATH="$JQ_DIR:$PATH"
     cd -
   fi
 

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -24,3 +24,11 @@ docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'chrome --no-sand
 
 # Display a size breakdown of the directories added by the buildpack to the app.
 docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'du --human-readable --max-depth=1 /app'
+
+
+# Verify that the milestone offset builds too
+docker build --progress=plain --build-arg="STACK_VERSION=${STACK_VERSION}" --build-arg="GOOGLE_CHROME_MILESTONE_OFFSET=-4" -t heroku-buildpack-chrome-for-testing .
+
+# Check the profile.d scripts correctly added the binaries to PATH.
+docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'chrome --version'
+docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'chromedriver --version'

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -25,7 +25,6 @@ docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'chrome --no-sand
 # Display a size breakdown of the directories added by the buildpack to the app.
 docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'du --human-readable --max-depth=1 /app'
 
-
 # Verify that the milestone offset builds too
 docker build --progress=plain --build-arg="STACK_VERSION=${STACK_VERSION}" --build-arg="GOOGLE_CHROME_MILESTONE_OFFSET=-4" -t heroku-buildpack-chrome-for-testing .
 


### PR DESCRIPTION
A workaround for recent Chrome 128 release incompatibility with Selenium,  

```
Selenium::WebDriver::Error::WebDriverError: disconnected: not connected to DevTools
```

This changeset provides a new build-time config var setting to install an older release.

See the branch's new README section, [Using an Older Chrome Release](https://github.com/heroku/heroku-buildpack-chrome-for-testing/blob/chrome-milestone-offset/README.md#using-an-older-chrome-release).

### Try this branch version on your app

```bash
heroku buildpacks:remove heroku-community/chrome-for-testing
heroku buildpacks:add -i 1 https://github.com/heroku/heroku-buildpack-chrome-for-testing.git#chrome-milestone-offset
```

To get the previous stable version of Chrome (currently v127), configure the app & then rebuild:

```bash
heroku config:set GOOGLE_CHROME_MILESTONE_OFFSET=-4
```