### PR TITLE
No more headless=old

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,13 @@ heroku buildpacks:add -i 1 heroku-community/chrome-for-testing
 
 Deploy the app to install Chrome for Testing. 🚀 
 
+## Launching `chrome`
+
+To execute in a Heroku dyno, `chrome` typically requires the flags:
+
+* `--headless`
+* `--no-sandbox`
+
 ## Selecting the Chrome Release Channel
 
 By default, this buildpack will download the latest `Stable` release, which is provided
@@ -56,7 +63,7 @@ These locations may change in future versions of this buildpack, so please allow
 
 ### Changes to Command Flags
 
-The prior `heroku/google-chrome` buildpack wrapped the `chrome` command with default flags using a shim script. This is no longer implemented for `chrome` in this buildpack, to support evolving changes to the Chrome for Testing flags, such as the [--headless=new variation](https://developer.chrome.com/docs/chromium/new-headless).
+The prior `heroku/google-chrome` buildpack wrapped the `chrome` command with default flags using a shim script. This is no longer implemented for `chrome` in this buildpack, to support evolving changes to the Chrome for Testing flags.
 
 Depending on how an app is already setup for testing with Chrome, it may not require any changes.
 

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -18,9 +18,8 @@ docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'chromedriver --v
 docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'ldd $(which chrome)'
 docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'ldd $(which chromedriver)'
 
-# Check Chrome can fully boot in both new and old headless modes.
-docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'chrome --no-sandbox --headless=new --screenshot https://google.com'
-docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'chrome --no-sandbox --headless=old --screenshot https://google.com'
+# Check Chrome can fully boot.
+docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'chrome --no-sandbox --screenshot https://google.com'
 
 # Display a size breakdown of the directories added by the buildpack to the app.
 docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'du --human-readable --max-depth=1 /app'

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -19,7 +19,7 @@ docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'ldd $(which chro
 docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'ldd $(which chromedriver)'
 
 # Check Chrome can fully boot.
-docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'chrome --no-sandbox --screenshot https://google.com'
+docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'chrome --no-sandbox --headless --screenshot https://google.com'
 
 # Display a size breakdown of the directories added by the buildpack to the app.
 docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'du --human-readable --max-depth=1 /app'


### PR DESCRIPTION
To solve [failing CI due to changes in Chrome](https://github.com/heroku/heroku-buildpack-chrome-for-testing/actions/runs/14366208416/job/40285328895?pr=37):

```
+ docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'chrome --no-sandbox --headless=old --screenshot https://google.com/'
Old Headless mode has been removed from the Chrome binary. Please use the
```