### PR TITLE
Add caching for Chrome binaries and APT packages

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -10,6 +10,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v5
     - name: Check Installation
       run: ./bin/test.sh ${{ matrix.stack_version }}

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -7,9 +7,9 @@ jobs:
     strategy:
       matrix:
         stack_version: [20, 22, 24]
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-${{ matrix.stack_version }}.04
 
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Check Installation
       run: ./bin/test.sh ${{ matrix.stack_version }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,66 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+This is a Scalingo buildpack that installs Google Chrome browser and chromedriver for automated testing environments. It follows Chrome for Testing strategy to keep Chrome & chromedriver versions in-sync.
+
+## Architecture
+
+This is a Scalingo buildpack with the standard buildpack structure:
+
+- `bin/detect` - Always returns success to detect this buildpack
+- `bin/compile` - Main buildpack logic that downloads and installs Chrome & chromedriver
+- `bin/install-chrome-dependencies` - Installs system dependencies for Chrome
+- `bin/test.sh` - Test script that builds Docker container and validates installation
+
+### Key Components
+
+- **Chrome Installation**: Downloads Chrome for Testing binaries from Google's CDN based on channel (Stable/Beta/Dev/Canary)
+- **Chromedriver Installation**: Downloads matching chromedriver version automatically
+- **PATH Setup**: Adds Chrome and chromedriver to PATH via `.profile.d/chrome-for-testing.sh`
+- **Multi-stack Support**: Supports Scalingo stack versions 20, 22, and 24
+
+## Common Commands
+
+### Testing the Buildpack
+```bash
+./bin/test.sh <stack_version>
+```
+Where stack_version is 20, 22, or 24. This builds a Docker container and validates the Chrome installation.
+
+### Manual Docker Testing
+```bash
+# Build container
+docker build --progress=plain --build-arg="STACK_VERSION=24" -t scalingo-buildpack-chrome-for-testing .
+
+# Test Chrome version
+docker run --rm scalingo-buildpack-chrome-for-testing bash -l -c 'chrome --version'
+
+# Test chromedriver version
+docker run --rm scalingo-buildpack-chrome-for-testing bash -l -c 'chromedriver --version'
+
+# Test Chrome functionality
+docker run --rm scalingo-buildpack-chrome-for-testing bash -l -c 'chrome --no-sandbox --headless --screenshot https://google.com'
+```
+
+## Configuration
+
+### Environment Variables
+- `GOOGLE_CHROME_CHANNEL`: Controls Chrome release channel (Stable, Beta, Dev, Canary). Defaults to Stable.
+
+### Required Chrome Flags for Scalingo
+When running Chrome in Scalingo environments, these flags are typically required:
+- `--headless`
+- `--no-sandbox`
+
+Additional flags that may be needed:
+- `--disable-gpu`
+- `--remote-debugging-port=9222`
+
+## Installation Paths
+- Chrome: `/app/.chrome-for-testing/chrome-linux64/chrome`
+- Chromedriver: `/app/.chrome-for-testing/chromedriver-linux64/chromedriver`
+
+These are added to PATH automatically, so `chrome` and `chromedriver` commands work directly.

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,3 +1,0 @@
-#ECCN:Open Source
-#GUSINFO:Heroku FE Infra & Arch,Heroku Front-End Infra
-* @heroku/front-end-infra

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,32 +1,28 @@
-ARG STACK_VERSION
-FROM --platform=linux/amd64 heroku/heroku:${STACK_VERSION}-build as build
+# syntax=docker/dockerfile:1-labs
+
+ARG STACK_VERSION=24
+ARG TARGETPLATFORM=linux/amd64
+
+FROM --platform=$TARGETPLATFORM scalingo/scalingo-${STACK_VERSION}:latest AS build
 
 # This ARG duplication is required since the lines before and after the 'FROM' are in different scopes.
 ARG STACK_VERSION
-ENV STACK="heroku-${STACK_VERSION}"
+ENV STACK="scalingo-${STACK_VERSION}"
 
-# On Heroku-24 and later the default user is not root.
-# Once support for Heroku-22 and older is removed, the `useradd` steps below can be removed.
-USER root
-
-# Emulate the platform where root access is not available
-RUN useradd -m non-root-user
-USER non-root-user
+# On Scalingo-24 and later the default user is not root.
+USER appsdeck
 RUN mkdir -p /tmp/build /tmp/cache /tmp/env
-COPY --chown=non-root-user . /buildpack
+COPY --chown=appsdeck . /buildpack
 
 # Sanitize the environment seen by the buildpack, to prevent reliance on
-# environment variables that won't be present when it's run by Heroku CI.
+# environment variables that won't be present when it's run by Scalingo CI.
 RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/detect /tmp/build
 RUN env -i PATH=$PATH HOME=$HOME STACK=$STACK /buildpack/bin/compile /tmp/build /tmp/cache /tmp/env
 
 # We must then test against the run image since that has fewer system libraries installed.
-FROM --platform=linux/amd64 heroku/heroku:${STACK_VERSION}
-USER root
-# Emulate the platform where root access is not available
-RUN useradd -m non-root-user
-USER non-root-user
-COPY --from=build --chown=non-root-user /tmp/build /app
+FROM --platform=$TARGETPLATFORM scalingo/scalingo-${STACK_VERSION}:latest
+COPY --from=build --chown=appsdeck /tmp/build /app
+USER appsdeck
 # Emulate the platform which sources all .profile.d/ scripts on app boot.
 RUN echo 'for f in /app/.profile.d/*; do source "${f}"; done' > /app/.profile
 ENV HOME=/app

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Heroku Buildpack, Chrome for Testing
+# Scalingo Buildpack, Chrome for Testing
 
-This buildpack installs **Google Chrome browser** `chrome` & [`chromedriver`](https://chromedriver.chromium.org/), the Selenium driver for Chrome, in a Heroku app.
+This buildpack installs **Google Chrome browser** `chrome` & [`chromedriver`](https://chromedriver.chromium.org/), the Selenium driver for Chrome, in a Scalingo app.
 
 ## Background
 
@@ -12,14 +12,14 @@ In summer 2023, the Chrome development team [addressed a long-standing problem w
 > If migrating from a previous Chrome-chromedriver installation, then remove any pre-existing Chrome or Chromedriver buildpacks from the app. See the [migration guide](#migrating-from-separate-buildpacks).
 
 ```bash
-heroku buildpacks:add -i 1 heroku-community/chrome-for-testing
+sed -i '1i https://github.com/yespark/scalingo-buildpack-chrome-for-testing' .buildpacks
 ```
 
 Deploy the app to install Chrome for Testing. 🚀 
 
 ## Launching `chrome`
 
-To execute in a Heroku dyno, `chrome` typically requires the flags:
+To execute in a Scalingo dyno, `chrome` typically requires the flags:
 
 * `--headless`
 * `--no-sandbox`
@@ -36,14 +36,7 @@ config variable to `Stable`, `Beta`, `Dev`, or `Canary`, and then deploy/build t
 
 ### Remove Existing Installations
 
-When an app already uses the separate Chrome & Chromedriver buildpacks, remove them from the app, before adding this one:
-
-```
-heroku buildpacks:remove heroku/google-chrome
-heroku buildpacks:remove heroku/chromedriver
-
-heroku buildpacks:add -i 1 heroku-community/chrome-for-testing
-```
+When an app already uses the separate Chrome & Chromedriver buildpacks, remove them from the .buildpacks file, before adding this one.
 
 ### Path to Installed Executables
 
@@ -52,7 +45,7 @@ After being installed by this buildpack, `chrome` & `chromedriver` are set in th
 If the absolute paths are required, you can discover their location in an app:
 
 ```bash
->>> heroku run bash
+>>> scalingo run bash
 $ which chrome
 /app/.chrome-for-testing/chrome-linux64/chrome
 $ which chromedriver
@@ -81,5 +74,4 @@ Some use-cases may require these flags too:
 
 *For buildpack maintainers only.*
 
-1. [Create a new release](https://github.com/heroku/heroku-buildpack-chrome-for-testing/releases/new) on GitHub.
-1. [Publish the release tag](https://addons-next.heroku.com/buildpacks/eb9c36ef-a265-4ea3-9468-2cd0fc3f04c1/publish) in Heroku Buildpack Registry.
+1. [Create a new release](https://github.com/yespark/scalingo-buildpack-chrome-for-testing/releases/new) on GitHub.

--- a/bin/compile
+++ b/bin/compile
@@ -36,6 +36,10 @@ topic "Installing Chrome for Testing"
 INSTALL_DIR="$BUILD_DIR/.chrome-for-testing"
 mkdir -p "$INSTALL_DIR"
 
+# Set up cache directories for Chrome downloads
+CHROME_CACHE_DIR="$CACHE_DIR/chrome-for-testing"
+mkdir -p "$CHROME_CACHE_DIR"
+
 # Detect if the old config var is still used
 if [ -f "$ENV_DIR/CHROMEDRIVER_VERSION" ]; then
   error "This buildpack no longer supports CHROMEDRIVER_VERSION config var and must be removed to continue, because this buildpack now installs compatible versions of Chrome & Chromedriver. GOOGLE_CHROME_CHANNEL can be used to set Stable (default), Beta, Dev, or Canary."
@@ -58,19 +62,31 @@ CHANNEL="$(echo -n "$channel" | awk '{ print toupper($0) }')"
 VERSION="$(curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 "https://googlechromelabs.github.io/chrome-for-testing/LATEST_RELEASE_$CHANNEL")"
 echo "Resolved $CHANNEL version $VERSION" | indent
 
-echo "Downloading Chrome" | indent
-ZIP_URL="https://storage.googleapis.com/chrome-for-testing-public/$VERSION/linux64/chrome-linux64.zip"
-ZIP_LOCATION="$INSTALL_DIR/chrome.zip"
-curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 -o "${ZIP_LOCATION}" "${ZIP_URL}" | indent
-unzip -q -o "$ZIP_LOCATION" -d "$INSTALL_DIR" | indent
-rm -f "$ZIP_LOCATION"
+# Check if Chrome is already cached for this version
+CHROME_CACHE_FILE="$CHROME_CACHE_DIR/chrome-$VERSION.zip"
+if [ -f "$CHROME_CACHE_FILE" ]; then
+  echo "Using cached Chrome $VERSION" | indent
+else
+  echo "Downloading Chrome" | indent
+  ZIP_URL="https://storage.googleapis.com/chrome-for-testing-public/$VERSION/linux64/chrome-linux64.zip"
+  curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 -o "${CHROME_CACHE_FILE}" "${ZIP_URL}" | indent
+fi
+unzip -q -o "$CHROME_CACHE_FILE" -d "$INSTALL_DIR" | indent
 
-echo "Downloading Chromedriver" | indent
-ZIP_URL="https://storage.googleapis.com/chrome-for-testing-public/$VERSION/linux64/chromedriver-linux64.zip"
-ZIP_LOCATION="$INSTALL_DIR/chromedriver.zip"
-curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 -o "${ZIP_LOCATION}" "${ZIP_URL}" | indent
-unzip -q -o "$ZIP_LOCATION" -d "$INSTALL_DIR" | indent
-rm -f "$ZIP_LOCATION"
+# Check if Chromedriver is already cached for this version
+CHROMEDRIVER_CACHE_FILE="$CHROME_CACHE_DIR/chromedriver-$VERSION.zip"
+if [ -f "$CHROMEDRIVER_CACHE_FILE" ]; then
+  echo "Using cached Chromedriver $VERSION" | indent
+else
+  echo "Downloading Chromedriver" | indent
+  ZIP_URL="https://storage.googleapis.com/chrome-for-testing-public/$VERSION/linux64/chromedriver-linux64.zip"
+  curl --silent --show-error --fail --retry 3 --retry-connrefused --connect-timeout 10 -o "${CHROMEDRIVER_CACHE_FILE}" "${ZIP_URL}" | indent
+fi
+unzip -q -o "$CHROMEDRIVER_CACHE_FILE" -d "$INSTALL_DIR" | indent
+
+# Clean up old cached versions to prevent cache bloat (keep only 3 most recent)
+ls -t "$CHROME_CACHE_DIR"/chrome-*.zip 2>/dev/null | tail -n +4 | xargs rm -f 2>/dev/null || true
+ls -t "$CHROME_CACHE_DIR"/chromedriver-*.zip 2>/dev/null | tail -n +4 | xargs rm -f 2>/dev/null || true
 
 source "$BUILDPACK_DIR/bin/install-chrome-dependencies"
 

--- a/bin/compile
+++ b/bin/compile
@@ -77,6 +77,7 @@ source "$BUILDPACK_DIR/bin/install-chrome-dependencies"
 echo "Adding executables to PATH" | indent
 mkdir -p "$BUILD_DIR/.profile.d"
 echo "export PATH=\$HOME/.chrome-for-testing/chrome-linux64:\$HOME/.chrome-for-testing/chromedriver-linux64:\$PATH" >> "$BUILD_DIR/.profile.d/chrome-for-testing.sh"
+echo "export BROWSER_PATH=\$HOME/.chrome-for-testing/chrome-linux64/chrome" >> "$BUILD_DIR/.profile.d/chrome-for-testing.sh"
 
 # Verify the executables are actually present
 export PATH="$BUILD_DIR/.chrome-for-testing/chrome-linux64:$BUILD_DIR/.chrome-for-testing/chromedriver-linux64:$PATH"

--- a/bin/install-chrome-dependencies
+++ b/bin/install-chrome-dependencies
@@ -16,6 +16,8 @@ topic "Installing Chrome dependencies"
 # Install correct dependencies according to $STACK
 # The package list is validated by bin/test.sh - see its output to identify any missing libraries.
 # Also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
+# Note: libnspr4 and libnss3 are required for Chrome 140+ on Ubuntu scalingo image
+# Without these, Chrome fails with "error while loading shared libraries"
 case "${STACK}" in
   "scalingo-20" | "scalingo-22")
     PACKAGES="
@@ -25,6 +27,8 @@ case "${STACK}" in
       libatk1.0-0
       libcups2
       libgbm1
+      libnspr4
+      libnss3
       libxcomposite1
       libxdamage1
       libxfixes3
@@ -48,8 +52,6 @@ case "${STACK}" in
       libxkbcommon0
       libxrandr2
     "
-    # Note: libnspr4 and libnss3 are required for Chrome 140+ on Ubuntu 24.04
-    # Without these, Chrome fails with "error while loading shared libraries"
     ;;
   *)
     error "STACK must be 'scalingo-20', 'scalingo-22' or 'scalingo-24', not '${STACK}'."

--- a/bin/install-chrome-dependencies
+++ b/bin/install-chrome-dependencies
@@ -17,7 +17,7 @@ topic "Installing Chrome dependencies"
 # The package list is validated by bin/test.sh - see its output to identify any missing libraries.
 # Also look here for more packages/notes https://developers.google.com/web/tools/puppeteer/troubleshooting
 case "${STACK}" in
-  "heroku-20" | "heroku-22")
+  "scalingo-20" | "scalingo-22")
     PACKAGES="
       fonts-liberation
       libasound2
@@ -32,7 +32,7 @@ case "${STACK}" in
       libxrandr2
     "
     ;;
-  "heroku-24")
+  "scalingo-24")
     PACKAGES="
       fonts-liberation
       libasound2t64
@@ -40,15 +40,19 @@ case "${STACK}" in
       libatk1.0-0
       libcups2
       libgbm1
+      libnspr4
+      libnss3
       libxcomposite1
       libxdamage1
       libxfixes3
       libxkbcommon0
       libxrandr2
     "
+    # Note: libnspr4 and libnss3 are required for Chrome 140+ on Ubuntu 24.04
+    # Without these, Chrome fails with "error while loading shared libraries"
     ;;
   *)
-    error "STACK must be 'heroku-20', 'heroku-22' or 'heroku-24', not '${STACK}'."
+    error "STACK must be 'scalingo-20', 'scalingo-22' or 'scalingo-24', not '${STACK}'."
 esac
 
 # We must invalidate the cache if the stack changes, since the cached indexes and

--- a/bin/install-chrome-dependencies
+++ b/bin/install-chrome-dependencies
@@ -64,6 +64,9 @@ esac
 # time, so we have to match that, given this buildpack and the APT buildpack share all the
 # other cached APT directories.
 STACK_VERSION_FILE="${CACHE_DIR}/.apt/STACK"
+CACHE_TIMESTAMP_FILE="${CACHE_DIR}/.apt/TIMESTAMP"
+CACHE_MAX_AGE_DAYS=7
+CACHE_CLEARED=false
 
 if [[ -d "${CACHE_DIR}/apt" ]]; then
   if [[ -f "${STACK_VERSION_FILE}" ]]; then
@@ -72,21 +75,40 @@ if [[ -d "${CACHE_DIR}/apt" ]]; then
     CACHED_STACK=
   fi
 
-  if [[ "${CACHED_STACK}" == "${STACK}" ]]; then
-    echo "Reusing APT cache" | indent
-  elif [[ -z "${CACHED_STACK}" ]]; then
-    # Older versions of the buildpack won't have written the version file.
-    # (Plus any other broken APT-related buildpacks that don't invalidate on cache change.)
-    echo "Clearing APT cache since it's missing the stack version metadata file." | indent
-    rm -rf "${CACHE_DIR}/apt"
-  else
-    echo "Clearing APT cache since stack changed from ${CACHED_STACK} to ${STACK}" | indent
-    rm -rf "${CACHE_DIR}/apt"
+  # Check cache age
+  if [[ -f "${CACHE_TIMESTAMP_FILE}" ]]; then
+    CACHE_TIMESTAMP=$(cat "${CACHE_TIMESTAMP_FILE}")
+    CURRENT_TIMESTAMP=$(date +%s)
+    CACHE_AGE_DAYS=$(( (CURRENT_TIMESTAMP - CACHE_TIMESTAMP) / 86400 ))
+    
+    if [[ ${CACHE_AGE_DAYS} -gt ${CACHE_MAX_AGE_DAYS} ]]; then
+      echo "Clearing APT cache since it's ${CACHE_AGE_DAYS} days old (max: ${CACHE_MAX_AGE_DAYS} days)" | indent
+      rm -rf "${CACHE_DIR}/apt"
+      CACHE_CLEARED=true
+    fi
+  fi
+
+  # Check if cache still exists after potential age-based clearing
+  if [[ -d "${CACHE_DIR}/apt" ]]; then
+    if [[ "${CACHED_STACK}" == "${STACK}" ]]; then
+      echo "Reusing APT cache" | indent
+    elif [[ -z "${CACHED_STACK}" ]]; then
+      # Older versions of the buildpack won't have written the version file.
+      # (Plus any other broken APT-related buildpacks that don't invalidate on cache change.)
+      echo "Clearing APT cache since it's missing the stack version metadata file." | indent
+      rm -rf "${CACHE_DIR}/apt"
+      CACHE_CLEARED=true
+    else
+      echo "Clearing APT cache since stack changed from ${CACHED_STACK} to ${STACK}" | indent
+      rm -rf "${CACHE_DIR}/apt"
+      CACHE_CLEARED=true
+    fi
   fi
 fi
 
 mkdir -p "${CACHE_DIR}/.apt"
 echo "${STACK}" > "${STACK_VERSION_FILE}"
+date +%s > "${CACHE_TIMESTAMP_FILE}"
 
 APT_CACHE_DIR="$CACHE_DIR/apt/cache"
 APT_STATE_DIR="$CACHE_DIR/apt/state"
@@ -96,9 +118,14 @@ mkdir -p "$APT_STATE_DIR/lists/partial"
 
 APT_OPTIONS="-o debug::nolocking=true -o dir::cache=$APT_CACHE_DIR -o dir::state=$APT_STATE_DIR"
 
-echo "Updating APT package index" | indent
-apt-get $APT_OPTIONS update | indent
+if [[ "$CACHE_CLEARED" == "true" ]] || [[ "${CACHED_STACK}" != "${STACK}" ]]; then
+  echo "Updating APT package index" | indent
+  apt-get $APT_OPTIONS update | indent
+else
+  echo "Using cached APT package index" | indent
+fi
 
+PACKAGES_NEEDED=false
 for PACKAGE in $PACKAGES; do
   if [[ $PACKAGE == *deb ]]; then
     PACKAGE_NAME=$(basename $PACKAGE .deb)
@@ -107,17 +134,30 @@ for PACKAGE in $PACKAGES; do
     echo "Fetching $PACKAGE" | indent
     curl -s -L -z $PACKAGE_FILE -o $PACKAGE_FILE $PACKAGE 2>&1 | indent
   else
-    echo "Fetching .debs for $PACKAGE" | indent
-    apt-get $APT_OPTIONS -y --force-yes -d install --reinstall --no-install-recommends $PACKAGE | indent
+    # Check if package needs to be downloaded
+    OUTPUT=$(apt-get $APT_OPTIONS -y --force-yes -d install --no-install-recommends $PACKAGE 2>&1)
+    if echo "$OUTPUT" | grep -q "Need to get [1-9]"; then
+      PACKAGES_NEEDED=true
+      echo "Fetching .debs for $PACKAGE" | indent
+      echo "$OUTPUT" | indent
+    fi
   fi
 done
 
 mkdir -p $BUILD_DIR/.apt
 
-for DEB in $(ls -1 $APT_CACHE_DIR/archives/*.deb); do
-  echo "Installing $(basename $DEB)" | indent
-  dpkg -x $DEB $BUILD_DIR/.apt/
-done
+if [[ "$PACKAGES_NEEDED" == "true" ]]; then
+  echo "Installing packages" | indent
+  for DEB in $(ls -1 $APT_CACHE_DIR/archives/*.deb); do
+    echo "  $(basename $DEB)" | indent
+    dpkg -x $DEB $BUILD_DIR/.apt/
+  done
+else
+  echo "Extracting cached packages" | indent
+  for DEB in $(ls -1 $APT_CACHE_DIR/archives/*.deb); do
+    dpkg -x $DEB $BUILD_DIR/.apt/
+  done
+fi
 
 echo "Writing profile script" | indent
 mkdir -p $BUILD_DIR/.profile.d

--- a/bin/test.sh
+++ b/bin/test.sh
@@ -6,20 +6,17 @@ STACK_VERSION="${1:?'Error: The stack version number must be specified as the fi
 
 set -x
 
-docker build --progress=plain --build-arg="STACK_VERSION=${STACK_VERSION}" -t heroku-buildpack-chrome-for-testing .
+docker build --platform=linux/amd64 --progress=plain --build-arg="STACK_VERSION=${STACK_VERSION}" -t scalingo-buildpack-chrome-for-testing .
 
 # Note: All of the container commands must be run via a login bash shell otherwise the profile.d scripts won't be run.
 
-# Check the profile.d scripts correctly added the binaries to PATH.
-docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'chrome --version'
-docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'chromedriver --version'
+# # Check the profile.d scripts correctly added the binaries to PATH.
+docker run --platform=linux/amd64 --rm scalingo-buildpack-chrome-for-testing bash -l -c 'chrome --version'
+docker run --platform=linux/amd64 --rm scalingo-buildpack-chrome-for-testing bash -l -c 'chromedriver --version'
 
-# Check that there are no missing dynamically linked libraries.
-docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'ldd $(which chrome)'
-docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'ldd $(which chromedriver)'
+# # Check that there are no missing dynamically linked libraries.
+docker run --platform=linux/amd64 --rm scalingo-buildpack-chrome-for-testing bash -l -c 'ldd $(which chrome)'
+docker run --platform=linux/amd64 --rm scalingo-buildpack-chrome-for-testing bash -l -c 'ldd $(which chromedriver)'
 
-# Check Chrome can fully boot.
-docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'chrome --no-sandbox --headless --screenshot https://google.com'
-
-# Display a size breakdown of the directories added by the buildpack to the app.
-docker run --rm heroku-buildpack-chrome-for-testing bash -l -c 'du --human-readable --max-depth=1 /app'
+# # Display a size breakdown of the directories added by the buildpack to the app.
+docker run --platform=linux/amd64 --rm scalingo-buildpack-chrome-for-testing bash -l -c 'du --human-readable --max-depth=1 /app'


### PR DESCRIPTION
## Summary
- Cache Chrome and Chromedriver downloads by version to speed up subsequent builds
- Add time-based expiration (7 days) for APT package cache with proper invalidation
- Skip redundant `apt-get update` and package downloads when cache is valid
