### PR TITLE
Add Dependabot configuration

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,11 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"
+    groups:
+      github-actions:
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
## Summary

Adds a `.github/dependabot.yml` to enable automated dependency updates for this repository.

- **`github-actions`** — keeps the actions used in `.github/workflows` up to date (currently `actions/checkout`). Minor/patch bumps are grouped into a single PR; majors open individually.

This is the only applicable ecosystem: the buildpack is pure shell (`bin/compile`, `bin/detect`), Chrome/Chromedriver are resolved dynamically at build time, system libs are installed via unpinned `apt` package names, and the Dockerfile's base image tag is a templated build `ARG` — none of which Dependabot can track. The config mirrors the minimal house style used by sibling repos such as `heroku-buildpack-go`.

## Work Item

GUS: [W-23296840](https://gus.lightning.force.com/lightning/r/ADM_Work__c/a07EE00002dotC0YAI/view) — Dependabot Configuration Issue - heroku/heroku-buildpack-chrome-for-testing